### PR TITLE
Change logo link to app home, add "About" navigation item

### DIFF
--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-light">
   <div class="container">
-    <a class="navbar-brand" href="https://zweirat-stuttgart.de/projekte/openbikesensor/">OpenBikeSensor</a>
+    <a class="navbar-brand" routerLink="/">OpenBikeSensor</a>
 
     <!-- Show this for logged out users -->
     <ul *appShowAuthed="false" class="nav navbar-nav pull-xs-right">
@@ -10,6 +10,13 @@
           Home
         </a>
       </li>
+
+      <li class="nav-item">
+        <a class="nav-link" href="https://zweirat-stuttgart.de/projekte/openbikesensor/" target="_blank">
+          About
+        </a>
+      </li>
+
 
       <li class="nav-item">
         <a class="nav-link" routerLink="/auth/login" routerLinkActive="active">
@@ -31,6 +38,12 @@
       <li class="nav-item">
         <a class="nav-link" routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
           Home
+        </a>
+      </li>
+
+      <li class="nav-item">
+        <a class="nav-link" href="https://zweirat-stuttgart.de/projekte/openbikesensor/" target="_blank">
+          About
         </a>
       </li>
 


### PR DESCRIPTION
This is confusing me over and over again while developing: I think the icon on top of the app should always link to the start of the app, not to some other site.

I've changed that, and added an "About" item to the navigation instead for the link to the project description over at [Zweirat Stuttgart](https://zweirat-stuttgart.de/projekte/openbikesensor/).