### PR TITLE
Fix "visible" checkmark

### DIFF
--- a/src/app/editor/editor.component.html
+++ b/src/app/editor/editor.component.html
@@ -7,33 +7,76 @@
 
         <form [formGroup]="trackForm">
           <fieldset [disabled]="isSubmitting">
-
             <fieldset class="form-group">
-              <input class="form-control form-control-lg"
+              <label for="title">Title</label>
+              <input
+                id="title"
                 formControlName="title"
                 type="text"
-                placeholder="Track Title" />
+                class="form-control form-control-lg" />
             </fieldset>
 
             <fieldset class="form-group">
-              <input class="form-control"
+              <label for="description">Description</label>
+              <textarea
+                id="description"
                 formControlName="description"
-                type="text"
-                placeholder="track description" />
-            </fieldset>
-
-            <fieldset class="form-group">
-              <textarea class="form-control"
-                formControlName="body"
-                rows="8"
-                placeholder="dummy track data">
+                rows="6"
+                class="form-control">
               </textarea>
             </fieldset>
 
-            <button class="btn btn-lg pull-xs-right btn-primary" type="button" (click)="submitForm()">
-              Add new Track
-            </button>
+            <fieldset class="form-group">
+              <label for="body">Track data</label>
+              <textarea
+                id="body"
+                class="form-control"
+                formControlName="body"
+                rows="6">
+              </textarea>
+              <p class="text-muted">
+                Paste your whole CSV file into this text field.
+                <span *ngIf="existing"> Leave empty to keep the current track data.</span>
+              </p>
+            </fieldset>
 
+            <fieldset class="form-group">
+              <input
+                type="checkbox"
+                id="visible"
+                formControlName="visible"
+                style="float: left; margin: 0.3rem;">
+              <div style="margin-left: 1.5rem;">
+                <label for="visible">Make track visible in public track list</label>
+                &nbsp;
+                <button class="btn btn-sm btn-secondary" (click)="toggleVisibleInfo()">
+                  <i class="ion-alert-circled"></i>
+                  Privacy info
+                </button>
+
+                <div *ngIf="visibleInfoVisible">
+                <p>
+                  Checking this box allows all users to see your full track.
+                  For your own privacy and security, make sure to only publish
+                  tracks in this way that do not let others deduct where you
+                  live, work, or frequently stay. Your recording device might
+                  have useful privacy settings to not record geolocation data
+                  near those places.
+                </p>
+                <p>
+                  In the future, this site will allow you to redact privacy
+                  sensitive data in tracks, both manually and automatically.
+                  Until then, you will have to rely on the features of your
+                  recording device, or manually redact your files before upload.
+                </p>
+                <p><b>Use at your own risk.</b></p>
+                </div>
+              </div>
+            </fieldset>
+
+            <button class="btn btn-primary" type="button" (click)="submitForm()">
+              {{existing ? 'Save details' : 'Add new Track'}}
+            </button>
           </fieldset>
         </form>
 

--- a/src/app/editor/editor.component.ts
+++ b/src/app/editor/editor.component.ts
@@ -12,7 +12,9 @@ export class EditorComponent implements OnInit {
   track: Track = {} as Track;
   trackForm: FormGroup;
   errors: Object = {};
+  existing = false;
   isSubmitting = false;
+  visibleInfoVisible = false;
 
   constructor(
     private tracksService: TracksService,
@@ -24,7 +26,8 @@ export class EditorComponent implements OnInit {
     this.trackForm = this.fb.group({
       title: '',
       description: '',
-      body: ''
+      body: '',
+      visible: false,
     });
 
     // Optional: subscribe to value changes on the form
@@ -45,6 +48,7 @@ export class EditorComponent implements OnInit {
         this.track = {...data.track};
         this.track.body = null
         this.trackForm.patchValue(this.track);
+        this.existing = true
       }
     });
   }
@@ -67,5 +71,9 @@ export class EditorComponent implements OnInit {
 
   updateTrack(values: Object) {
     Object.assign(this.track, values);
+  }
+
+  toggleVisibleInfo() {
+    this.visibleInfoVisible  = !this.visibleInfoVisible ;
   }
 }

--- a/src/app/track/track.component.html
+++ b/src/app/track/track.component.html
@@ -48,14 +48,14 @@ cursor: pointer;
       <div class="col-md-12">
 
         <div [innerHTML]="track.description | markdown"></div>
-        
+
       </div>
       <div class="col-md-12">
 
         <div class="map-frame">
           <div id="trackMapView"></div>
         </div>
-        
+
       </div>
     </div>
 
@@ -63,6 +63,9 @@ cursor: pointer;
 
     <div class="track-actions">
       <app-track-meta [track]="track">
+        <i class="{{ track.visible ? 'ion-eye' : 'ion-eye-disabled' }}"></i>
+        {{ track.visible ? 'Visible' : 'Private' }}
+
 
           <span [hidden]="!canModify">
           <a class="btn btn-sm btn-outline-secondary"
@@ -75,13 +78,8 @@ cursor: pointer;
             (click)="deleteTrack()">
             <i class="ion-trash-a"></i> Delete Track
           </button>
-          
-            <label><input class="btn btn-sm btn-outline-danger"
-              type="checkbox"
-              (change)="onChange($event.target.checked)"
-              checked="{{ track.visible }}"/> visible </label>
         </span>
-        
+
         <button class="btn btn-sm btn-outline-secondary"
         [ngClass]="{disabled: isExporting}"
         (click)="exportGPX()">


### PR DESCRIPTION
* Move checkmark from details page to editor.
* Add explanation what that checkmark means, and privacy warning.
* Show eye/no-eye symbol on track details page.
* Make editor prettier.

This needs an update of obsAPI to at least `11c806dbe317052d6c6ff3fa8c07227814b93335`. 